### PR TITLE
Fix property renamed in version 2.7+

### DIFF
--- a/projects/ngx-agora/src/lib/data/models/remote-stream-stats.model.ts
+++ b/projects/ngx-agora/src/lib/data/models/remote-stream-stats.model.ts
@@ -33,7 +33,7 @@ export interface RemoteStreamStats extends StreamStats {
   /** Number of lost packets of the received video. */
   videoReceivePacketsLost: string;
   /** Resolution height of the received video. */
-  videoReceivedResolutionHeight?: string;
+  videoReceiveResolutionHeight?: string;
   /** Resolution width of the received video. */
-  videoReceivedResolutionWidth?: string;
+  videoReceiveResolutionWidth?: string;
 }


### PR DESCRIPTION
videoReceivedResolutionHeight and videoReceivedResolutionWidth was renamed in 2.7+ version of agora to videoReceiveResolutionHeight and videoReceiveResolutionWidth (without the "d") https://docs.agora.io/en/cloud-recording/API%20Reference/web/v2.7/interfaces/agorartc.remotestreamstats.html